### PR TITLE
Add support for linux arm and aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
@@ -139,26 +139,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
@@ -206,9 +186,9 @@ checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
@@ -434,6 +414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,17 +457,6 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
@@ -498,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -534,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -547,17 +527,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "goblin"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
 
 [[package]]
 name = "goblin"
@@ -780,23 +749,12 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libproc"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
-dependencies = [
- "bindgen 0.64.0",
- "errno 0.2.8",
- "libc",
-]
-
-[[package]]
-name = "libproc"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229004ebba9d1d5caf41623f1523b6d52abb47d9f6ab87f7e6fc992e3b854aef"
 dependencies = [
- "bindgen 0.68.1",
- "errno 0.3.1",
+ "bindgen",
+ "errno",
  "libc",
 ]
 
@@ -945,9 +903,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "flate2",
  "memchr",
@@ -1053,9 +1011,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec8fdc22cb95c02f6a26a91fb1cd60a7a115916c2ed3b09d0a312e11785bd57"
 dependencies = [
  "anyhow",
- "bindgen 0.68.1",
+ "bindgen",
  "libc",
- "libproc 0.14.2",
+ "libproc",
  "mach2",
  "winapi",
 ]
@@ -1072,7 +1030,7 @@ dependencies = [
  "cpp_demangle",
  "ctrlc",
  "env_logger",
- "goblin 0.7.1",
+ "goblin",
  "indicatif",
  "inferno",
  "lazy_static",
@@ -1198,15 +1156,14 @@ checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remoteprocess"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91114d769bd6dffc9565c01bbba121ca223efba7fdbc4c57b63fd91c1ea8478e"
+version = "0.4.13"
+source = "git+https://github.com/technicianted/remoteprocess?branch=linux_aarch64#025d643fc5c29789e539701866cd8d1d5a0767c9"
 dependencies = [
  "addr2line",
- "goblin 0.6.1",
+ "goblin",
  "lazy_static",
  "libc",
- "libproc 0.13.0",
+ "libproc",
  "log",
  "mach",
  "mach_o_sys",
@@ -1247,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.1",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
@@ -1256,12 +1213,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "thiserror",
+ "derive_more",
  "twox-hash",
 ]
 
@@ -1432,26 +1389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "terminal_size",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "py-spy"
-version = "0.3.15+custom4"
+version = "0.3.15+custom5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-spy"
-version = "0.3.15+custom4"
+version = "0.3.15+custom5"
 authors = ["Ben Frederickson <github@benfrederickson.com>"]
 repository = "https://github.com/benfred/py-spy"
 homepage = "https://github.com/benfred/py-spy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 rand = "0.8"
 rand_distr = "0.4"
-remoteprocess = {version="0.4.12", features=["unwind"]}
+remoteprocess = {features=["unwind"], git="https://github.com/technicianted/remoteprocess", branch="linux_aarch64"}
 chrono = "0.4.26"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,13 @@
 use std::env;
 
 fn main() {
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64" {
-        return;
-    }
-
-    match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
-        "windows" => println!("cargo:rustc-cfg=unwind"),
-        "linux" => println!("cargo:rustc-cfg=unwind"),
-        _ => {}
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    match (target_arch.as_ref(), target_os.as_ref())  {
+        ("x86_64", "windows") |
+        ("x86_64", "linux") |
+        ("arm", "linux") |
+        ("aarch64", "linux")  =>  println!("cargo:rustc-cfg=unwind"),
+        _ => { }
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.15+custom4
+current_version = 0.3.15+custom5
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>(a|b|rc|\.dev)\d+))?

--- a/src/python_spy.rs
+++ b/src/python_spy.rs
@@ -564,10 +564,16 @@ impl PythonSpy {
         while let Some(_) = cursor.next() {
             // the pthread_id is usually in the top-level frame of the thread, but on some configs
             // can be 2nd level. Handle this by taking the top-most rbx value that is one of the
-            // pthread_ids we're looking for
-            if let Ok(bx) = cursor.bx() {
-                if bx != 0 && threadids.contains(&bx) {
-                    pthread_id = bx;
+            // pthread_ids we're looking for. for arm based arch, it is in r5.
+            #[cfg(target_arch = "x86_64")]
+            let thread_reg = cursor.bx();
+            #[cfg(target_arch = "arm")]
+            let thread_reg = cursor.r5();
+            #[cfg(target_arch = "aarch64")]
+            let thread_reg = cursor.r5();
+            if let Ok(thread_id) = thread_reg {
+                if thread_id != 0 && threadids.contains(&thread_id) {
+                    pthread_id = thread_id;
                 }
             }
         }


### PR DESCRIPTION
Currently uses `remoteprocess` fork until it is upstreamed: https://github.com/benfred/remoteprocess/pull/90.

Sample output:
```
$ py-spy dump --native --pid $(pidof python) --native-all
Process 16911: python ../test_ext.py
Python v3.11.2 (/usr/bin/python3.11)

Thread 16913 (idle)
    clock_nanosleep (/usr/lib/aarch64-linux-gnu/libc.so.6)
    nanosleep (/usr/lib/aarch64-linux-gnu/libc.so.6)
    std::thread::sleep::hc1de9d8155f6b6bd (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    std::sys_common::backtrace::__rust_begin_short_backtrace::he7a977a0bf9b5555 (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h2c50449586bc6ad1 (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    std::sys::pal::unix::thread::Thread::new::thread_start::haf793f2025a74235 (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    0xffffac72ee58 (/usr/lib/aarch64-linux-gnu/libc.so.6)
    0xffffac797f9c (/usr/lib/aarch64-linux-gnu/libc.so.6)
Thread 16912 (idle)
    clock_nanosleep (/usr/lib/aarch64-linux-gnu/libc.so.6)
    nanosleep (/usr/lib/aarch64-linux-gnu/libc.so.6)
    std::thread::sleep::hc1de9d8155f6b6bd (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    std::sys_common::backtrace::__rust_begin_short_backtrace::he7a977a0bf9b5555 (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h0b1627c9b4d174d8 (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    std::sys::pal::unix::thread::Thread::new::thread_start::haf793f2025a74235 (/workspaces/spy/penv/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    0xffffac72ee58 (/usr/lib/aarch64-linux-gnu/libc.so.6)
    0xffffac797f9c (/usr/lib/aarch64-linux-gnu/libc.so.6)
Thread 16911 (idle)
    0xffffac72b6d4 (libc.so.6)
    0xffffac730758 (libc.so.6)
    std::sys::pal::unix::thread::Thread::join::hc09d4a92d98a6bce (kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    std::thread::JoinInner$LT$T$GT$::join::h403478230c32e316 (kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    kf_rust_ext::kf_rust_ext::rust_function::hc9b2e994532d2d95 (kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    std::panicking::try::hd1c5c3042e85c102 (kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    kf_rust_ext::kf_rust_ext::__pyo3_raw_rust_function::hc3e7ee0364f63812 (kf_rust_ext/kf_rust_ext.cpython-311-aarch64-linux-gnu.so)
    <module> (test_ext.py:3)
    0xffffac6d7780 (libc.so.6)
```

similar x86_64:
```
Process 1379765: python ../test_ext.py
Python v3.11.8 (/root/.pyenv/versions/3.11.8/bin/python3.11)

Thread 1379767 (idle)
    clock_nanosleep (/usr/lib/x86_64-linux-gnu/libc-2.31.so)
    nanosleep (/usr/lib/x86_64-linux-gnu/libc-2.31.so)
    std::sys::unix::thread::Thread::sleep::he20c58a35e16b257 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys/unix/thread.rs:243)
    std::thread::sleep::h9e682f6cedf95ea6 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/thread/mod.rs:870)
    std::sys_common::backtrace::__rust_begin_short_backtrace::h95759f90066ca742 (/root/.pyenv/versions/3.11.8/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hb7e9b03113952b56 (/root/.pyenv/versions/3.11.8/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    core::mem::size_of_val_raw::hf6e096a56666bcf8 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/mem/mod.rs:394)
    core::alloc::layout::Layout::for_value_raw::h357745730b3a1a68 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/alloc/layout.rs:201)
    _$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$::drop::hf9199ed786409a3b (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:1241)
    _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h12de4fc57affb195 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2015)
    _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h3c619f45059d5cf1 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2015)
    std::sys::unix::thread::Thread::new::thread_start::hbac657605e4b7389 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys/unix/thread.rs:108)
    clone (/usr/lib/x86_64-linux-gnu/libc-2.31.so)
Thread 1379766 (idle)
    clock_nanosleep (/usr/lib/x86_64-linux-gnu/libc-2.31.so)
    nanosleep (/usr/lib/x86_64-linux-gnu/libc-2.31.so)
    std::sys::unix::thread::Thread::sleep::he20c58a35e16b257 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys/unix/thread.rs:243)
    std::thread::sleep::h9e682f6cedf95ea6 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/thread/mod.rs:870)
    std::sys_common::backtrace::__rust_begin_short_backtrace::h95759f90066ca742 (/root/.pyenv/versions/3.11.8/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h29f53fd57b55b2e7 (/root/.pyenv/versions/3.11.8/lib/python3.11/site-packages/kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    core::mem::size_of_val_raw::hf6e096a56666bcf8 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/mem/mod.rs:394)
    core::alloc::layout::Layout::for_value_raw::h357745730b3a1a68 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/core/src/alloc/layout.rs:201)
    _$LT$alloc..boxed..Box$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$::drop::hf9199ed786409a3b (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:1241)
    _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h12de4fc57affb195 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2015)
    _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h3c619f45059d5cf1 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/alloc/src/boxed.rs:2015)
    std::sys::unix::thread::Thread::new::thread_start::hbac657605e4b7389 (/rustc/07dca489ac2d933c78d3c5158e3f43beefeb02ce/library/std/src/sys/unix/thread.rs:108)
    clone (/usr/lib/x86_64-linux-gnu/libc-2.31.so)
Thread 1379765 (idle)
    __pthread_clockjoin_ex (libpthread-2.31.so)
    std::sys::unix::thread::Thread::join::h39b09a9c8f68b464 (thread.rs:271)
    std::thread::JoinInner$LT$T$GT$::join::h55e9f249cac9a458 (kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    kf_rust_ext::kf_rust_ext::rust_function::h302df3c6fd06be75 (kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    std::panicking::try::hbd9ef11a72c2dc65 (kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    kf_rust_ext::kf_rust_ext::__pyo3_raw_rust_function::h07890265fab78f5e (kf_rust_ext/kf_rust_ext.cpython-311-x86_64-linux-gnu.so)
    <module> (test_ext.py:3)
```